### PR TITLE
Use permissions enum directly in methods

### DIFF
--- a/src/me/armar/plugins/autorank/commands/AddCommand.java
+++ b/src/me/armar/plugins/autorank/commands/AddCommand.java
@@ -26,7 +26,7 @@ public class AddCommand extends AutorankCommand {
     @Override
     public boolean onCommand(final CommandSender sender, final Command cmd, final String label, final String[] args) {
 
-        if (!plugin.getCommandsManager().hasPermission(AutorankPermission.ADD_LOCAL_TIME.getPermissionString(), sender)) {
+        if (!plugin.getCommandsManager().hasPermission(AutorankPermission.ADD_LOCAL_TIME, sender)) {
             return true;
         }
 
@@ -69,8 +69,8 @@ public class AddCommand extends AutorankCommand {
     }
 
     @Override
-    public String getPermission() {
-        return AutorankPermission.ADD_LOCAL_TIME.getPermissionString();
+    public AutorankPermission getPermission() {
+        return AutorankPermission.ADD_LOCAL_TIME;
     }
 
     @Override

--- a/src/me/armar/plugins/autorank/commands/ArchiveCommand.java
+++ b/src/me/armar/plugins/autorank/commands/ArchiveCommand.java
@@ -25,7 +25,7 @@ public class ArchiveCommand extends AutorankCommand {
     @Override
     public boolean onCommand(final CommandSender sender, final Command cmd, final String label, final String[] args) {
 
-        if (!plugin.getCommandsManager().hasPermission(AutorankPermission.ARCHIVE_PLAYERS.getPermissionString(), sender)) {
+        if (!plugin.getCommandsManager().hasPermission(AutorankPermission.ARCHIVE_PLAYERS, sender)) {
             return true;
         }
 
@@ -56,8 +56,8 @@ public class ArchiveCommand extends AutorankCommand {
     }
 
     @Override
-    public String getPermission() {
-        return AutorankPermission.ARCHIVE_PLAYERS.getPermissionString();
+    public AutorankPermission getPermission() {
+        return AutorankPermission.ARCHIVE_PLAYERS;
     }
 
     @Override

--- a/src/me/armar/plugins/autorank/commands/CheckCommand.java
+++ b/src/me/armar/plugins/autorank/commands/CheckCommand.java
@@ -258,8 +258,7 @@ public class CheckCommand extends AutorankCommand {
         // This is a local check. It will not show you the database numbers
         if (args.length > 1) {
 
-            if (!plugin.getCommandsManager().hasPermission(AutorankPermission.CHECK_OTHERS.getPermissionString(),
-                    sender)) {
+            if (!plugin.getCommandsManager().hasPermission(AutorankPermission.CHECK_OTHERS, sender)) {
                 return true;
             }
 
@@ -289,7 +288,7 @@ public class CheckCommand extends AutorankCommand {
                 check(sender, player);
             }
         } else if (sender instanceof Player) {
-            if (!plugin.getCommandsManager().hasPermission(AutorankPermission.CHECK_SELF.getPermissionString(),
+            if (!plugin.getCommandsManager().hasPermission(AutorankPermission.CHECK_SELF,
                     sender)) {
                 return true;
             }
@@ -312,8 +311,8 @@ public class CheckCommand extends AutorankCommand {
     }
 
     @Override
-    public String getPermission() {
-        return AutorankPermission.CHECK_SELF.getPermissionString();
+    public AutorankPermission getPermission() {
+        return AutorankPermission.CHECK_SELF;
     }
 
     @Override

--- a/src/me/armar/plugins/autorank/commands/ChooseCommand.java
+++ b/src/me/armar/plugins/autorank/commands/ChooseCommand.java
@@ -30,7 +30,7 @@ public class ChooseCommand extends AutorankCommand {
     public boolean onCommand(final CommandSender sender, final Command cmd, final String label, final String[] args) {
 
         // This command will give a preview of a certain path of ranking.
-        if (!plugin.getCommandsManager().hasPermission(AutorankPermission.CHOOSE_PATH.getPermissionString(), sender)) {
+        if (!plugin.getCommandsManager().hasPermission(AutorankPermission.CHOOSE_PATH, sender)) {
             return true;
         }
 
@@ -124,8 +124,8 @@ public class ChooseCommand extends AutorankCommand {
     }
 
     @Override
-    public String getPermission() {
-        return AutorankPermission.CHOOSE_PATH.getPermissionString();
+    public AutorankPermission getPermission() {
+        return AutorankPermission.CHOOSE_PATH;
     }
 
     @Override

--- a/src/me/armar/plugins/autorank/commands/CompleteCommand.java
+++ b/src/me/armar/plugins/autorank/commands/CompleteCommand.java
@@ -44,7 +44,7 @@ public class CompleteCommand extends AutorankCommand {
             return true;
         }
 
-        if (!plugin.getCommandsManager().hasPermission(AutorankPermission.COMPLETE_REQUIREMENT.getPermissionString(), sender))
+        if (!plugin.getCommandsManager().hasPermission(AutorankPermission.COMPLETE_REQUIREMENT, sender))
             return true;
 
         final Player player = (Player) sender;
@@ -117,8 +117,8 @@ public class CompleteCommand extends AutorankCommand {
     }
 
     @Override
-    public String getPermission() {
-        return AutorankPermission.COMPLETE_REQUIREMENT.getPermissionString();
+    public AutorankPermission getPermission() {
+        return AutorankPermission.COMPLETE_REQUIREMENT;
     }
 
     @Override

--- a/src/me/armar/plugins/autorank/commands/ConvertUUIDCommand.java
+++ b/src/me/armar/plugins/autorank/commands/ConvertUUIDCommand.java
@@ -31,7 +31,7 @@ public class ConvertUUIDCommand extends AutorankCommand {
 
         if (targetFile.equalsIgnoreCase("playerdata")) {
 
-            if (!plugin.getCommandsManager().hasPermission(AutorankPermission.CONVERT_PLAYER_DATA.getPermissionString(), sender)) {
+            if (!plugin.getCommandsManager().hasPermission(AutorankPermission.CONVERT_PLAYER_DATA, sender)) {
                 return true;
             }
 
@@ -41,7 +41,7 @@ public class ConvertUUIDCommand extends AutorankCommand {
             sender.sendMessage(ChatColor.RED + "Converting playerdata.yml to use new UUID format.");
         } else if (targetFile.equalsIgnoreCase("data") || targetFile.equalsIgnoreCase("times")) {
 
-            if (!plugin.getCommandsManager().hasPermission(AutorankPermission.CONVERT_TIME_DATA.getPermissionString(), sender)) {
+            if (!plugin.getCommandsManager().hasPermission(AutorankPermission.CONVERT_TIME_DATA, sender)) {
                 return true;
             }
 
@@ -59,8 +59,8 @@ public class ConvertUUIDCommand extends AutorankCommand {
     }
 
     @Override
-    public String getPermission() {
-        return AutorankPermission.CONVERT_TIME_DATA.getPermissionString();
+    public AutorankPermission getPermission() {
+        return AutorankPermission.CONVERT_TIME_DATA;
     }
 
     @Override

--- a/src/me/armar/plugins/autorank/commands/DebugCommand.java
+++ b/src/me/armar/plugins/autorank/commands/DebugCommand.java
@@ -24,7 +24,7 @@ public class DebugCommand extends AutorankCommand {
 
         // This will create a 'debug.txt' file containing a lot of information
         // about the plugin
-        if (!plugin.getCommandsManager().hasPermission(AutorankPermission.DEBUG_FILE.getPermissionString(), sender)) {
+        if (!plugin.getCommandsManager().hasPermission(AutorankPermission.DEBUG_FILE, sender)) {
             return true;
         }
 
@@ -46,8 +46,8 @@ public class DebugCommand extends AutorankCommand {
     }
 
     @Override
-    public String getPermission() {
-        return AutorankPermission.DEBUG_FILE.getPermissionString();
+    public AutorankPermission getPermission() {
+        return AutorankPermission.DEBUG_FILE;
     }
 
     @Override

--- a/src/me/armar/plugins/autorank/commands/ForceCheckCommand.java
+++ b/src/me/armar/plugins/autorank/commands/ForceCheckCommand.java
@@ -25,7 +25,7 @@ public class ForceCheckCommand extends AutorankCommand {
     @Override
     public boolean onCommand(final CommandSender sender, final Command cmd, final String label, final String[] args) {
 
-        if (!plugin.getCommandsManager().hasPermission( AutorankPermission.FORCE_CHECK.getPermissionString(), sender))
+        if (!plugin.getCommandsManager().hasPermission( AutorankPermission.FORCE_CHECK, sender))
             return true;
 
         if (args.length != 2) {
@@ -61,8 +61,8 @@ public class ForceCheckCommand extends AutorankCommand {
     }
 
     @Override
-    public String getPermission() {
-        return AutorankPermission.FORCE_CHECK.getPermissionString();
+    public AutorankPermission getPermission() {
+        return AutorankPermission.FORCE_CHECK;
     }
 
     @Override

--- a/src/me/armar/plugins/autorank/commands/GlobalAddCommand.java
+++ b/src/me/armar/plugins/autorank/commands/GlobalAddCommand.java
@@ -26,7 +26,7 @@ public class GlobalAddCommand extends AutorankCommand {
     @Override
     public boolean onCommand(final CommandSender sender, final Command cmd, final String label, final String[] args) {
         
-        if (!plugin.getCommandsManager().hasPermission(AutorankPermission.ADD_GLOBAL_TIME.getPermissionString(), sender)) {
+        if (!plugin.getCommandsManager().hasPermission(AutorankPermission.ADD_GLOBAL_TIME, sender)) {
             return true;
         }
 
@@ -84,8 +84,8 @@ public class GlobalAddCommand extends AutorankCommand {
     }
 
     @Override
-    public String getPermission() {
-        return AutorankPermission.ADD_GLOBAL_TIME.getPermissionString();
+    public AutorankPermission getPermission() {
+        return AutorankPermission.ADD_GLOBAL_TIME;
     }
 
     @Override

--- a/src/me/armar/plugins/autorank/commands/GlobalCheckCommand.java
+++ b/src/me/armar/plugins/autorank/commands/GlobalCheckCommand.java
@@ -36,7 +36,7 @@ public class GlobalCheckCommand extends AutorankCommand {
 
         if (args.length > 1) {
 
-            if (!plugin.getCommandsManager().hasPermission(AutorankPermission.CHECK_OTHERS.getPermissionString(), sender)) {
+            if (!plugin.getCommandsManager().hasPermission(AutorankPermission.CHECK_OTHERS, sender)) {
                 return true;
             }
 
@@ -74,7 +74,7 @@ public class GlobalCheckCommand extends AutorankCommand {
                 return true;
 
             } else {
-                if (player.hasPermission(AutorankPermission.EXCLUDE_FROM_PATHING.getPermissionString())) {
+                if (AutorankPermission.EXCLUDE_FROM_PATHING.allows(player)) {
                     sender.sendMessage(ChatColor.RED + Lang.PLAYER_IS_EXCLUDED.getConfigValue(player.getName()));
                     return true;
                 }
@@ -105,11 +105,11 @@ public class GlobalCheckCommand extends AutorankCommand {
                 });
             }
         } else if (sender instanceof Player) {
-            if (!plugin.getCommandsManager().hasPermission(AutorankPermission.CHECK_GLOBAL.getPermissionString(), sender)) {
+            if (!plugin.getCommandsManager().hasPermission(AutorankPermission.CHECK_GLOBAL, sender)) {
                 return true;
             }
 
-            if (sender.hasPermission("autorank.exclude")) {
+            if (AutorankPermission.EXCLUDE_FROM_PATHING.allows(sender)) {
                 sender.sendMessage(ChatColor.RED + Lang.PLAYER_IS_EXCLUDED.getConfigValue(sender.getName()));
                 return true;
             }
@@ -140,8 +140,8 @@ public class GlobalCheckCommand extends AutorankCommand {
     }
 
     @Override
-    public String getPermission() {
-        return AutorankPermission.CHECK_GLOBAL.getPermissionString();
+    public AutorankPermission getPermission() {
+        return AutorankPermission.CHECK_GLOBAL;
     }
 
     @Override

--- a/src/me/armar/plugins/autorank/commands/GlobalSetCommand.java
+++ b/src/me/armar/plugins/autorank/commands/GlobalSetCommand.java
@@ -38,8 +38,7 @@ public class GlobalSetCommand extends AutorankCommand {
 
         if (value >= 0) {
 
-            if (!plugin.getCommandsManager().hasPermission(AutorankPermission.SET_GLOBAL_TIME.getPermissionString(),
-                    sender)) {
+            if (!plugin.getCommandsManager().hasPermission(AutorankPermission.SET_GLOBAL_TIME, sender)) {
                 return true;
             }
 
@@ -74,8 +73,8 @@ public class GlobalSetCommand extends AutorankCommand {
     }
 
     @Override
-    public String getPermission() {
-        return AutorankPermission.SET_GLOBAL_TIME.getPermissionString();
+    public AutorankPermission getPermission() {
+        return AutorankPermission.SET_GLOBAL_TIME;
     }
 
     @Override

--- a/src/me/armar/plugins/autorank/commands/HelpCommand.java
+++ b/src/me/armar/plugins/autorank/commands/HelpCommand.java
@@ -59,7 +59,7 @@ public class HelpCommand extends AutorankCommand {
                 for (final AutorankCommand cmd : commands) {
                     // Check if player has permission to do this, before
                     // presenting this command
-                    if (sender.hasPermission(cmd.getPermission())) {
+                    if (cmd.getPermission().allows(sender)) {
                         newList.add(cmd);
                     }
                 }
@@ -111,8 +111,8 @@ public class HelpCommand extends AutorankCommand {
     }
 
     @Override
-    public String getPermission() {
-        return AutorankPermission.HELP_PAGES.getPermissionString();
+    public AutorankPermission getPermission() {
+        return AutorankPermission.HELP_PAGES;
     }
 
     @Override

--- a/src/me/armar/plugins/autorank/commands/HooksCommand.java
+++ b/src/me/armar/plugins/autorank/commands/HooksCommand.java
@@ -57,8 +57,8 @@ public class HooksCommand extends AutorankCommand {
     }
 
     @Override
-    public String getPermission() {
-        return AutorankPermission.SHOW_HOOKS.getPermissionString();
+    public AutorankPermission getPermission() {
+        return AutorankPermission.SHOW_HOOKS;
     }
 
     @Override

--- a/src/me/armar/plugins/autorank/commands/ImportCommand.java
+++ b/src/me/armar/plugins/autorank/commands/ImportCommand.java
@@ -23,7 +23,7 @@ public class ImportCommand extends AutorankCommand {
     @Override
     public boolean onCommand(final CommandSender sender, final Command cmd, final String label, final String[] args) {
 
-        if (!plugin.getCommandsManager().hasPermission(AutorankPermission.IMPORT_DATA.getPermissionString(), sender)) {
+        if (!plugin.getCommandsManager().hasPermission(AutorankPermission.IMPORT_DATA, sender)) {
             return true;
         }
 
@@ -39,8 +39,8 @@ public class ImportCommand extends AutorankCommand {
     }
 
     @Override
-    public String getPermission() {
-        return AutorankPermission.IMPORT_DATA.getPermissionString();
+    public AutorankPermission getPermission() {
+        return AutorankPermission.IMPORT_DATA;
     }
 
     @Override

--- a/src/me/armar/plugins/autorank/commands/LeaderboardCommand.java
+++ b/src/me/armar/plugins/autorank/commands/LeaderboardCommand.java
@@ -24,7 +24,7 @@ public class LeaderboardCommand extends AutorankCommand {
     @Override
     public boolean onCommand(final CommandSender sender, final Command cmd, final String label, final String[] args) {
 
-        if (!plugin.getCommandsManager().hasPermission(AutorankPermission.VIEW_LEADERBOARD.getPermissionString(), sender)) {
+        if (!plugin.getCommandsManager().hasPermission(AutorankPermission.VIEW_LEADERBOARD, sender)) {
             return true;
         }
 
@@ -36,7 +36,7 @@ public class LeaderboardCommand extends AutorankCommand {
             if (arg.equalsIgnoreCase("force")) {
 
                 // Check for permission
-                if (!sender.hasPermission(AutorankPermission.FORCE_UPDATE_LEADERBOARD.getPermissionString())) {
+                if (!AutorankPermission.FORCE_UPDATE_LEADERBOARD.allows(sender)) {
                     sender.sendMessage(Lang.NO_PERMISSION.getConfigValue("autorank.leaderboard.force"));
                     return true;
                 }
@@ -45,7 +45,7 @@ public class LeaderboardCommand extends AutorankCommand {
             } else if (arg.equalsIgnoreCase("broadcast")) {
 
                 // Check for permission
-                if (!sender.hasPermission(AutorankPermission.BROADCAST_LEADERBOARD.getPermissionString())) {
+                if (!AutorankPermission.BROADCAST_LEADERBOARD.allows(sender)) {
                     sender.sendMessage(Lang.NO_PERMISSION.getConfigValue("autorank.leaderboard.broadcast"));
                     return true;
                 }
@@ -110,8 +110,8 @@ public class LeaderboardCommand extends AutorankCommand {
     }
 
     @Override
-    public String getPermission() {
-        return AutorankPermission.VIEW_LEADERBOARD.getPermissionString();
+    public AutorankPermission getPermission() {
+        return AutorankPermission.VIEW_LEADERBOARD;
     }
 
     @Override

--- a/src/me/armar/plugins/autorank/commands/ReloadCommand.java
+++ b/src/me/armar/plugins/autorank/commands/ReloadCommand.java
@@ -23,7 +23,7 @@ public class ReloadCommand extends AutorankCommand {
     @Override
     public boolean onCommand(final CommandSender sender, final Command cmd, final String label, final String[] args) {
 
-        if (!plugin.getCommandsManager().hasPermission(AutorankPermission.RELOAD_AUTORANK.getPermissionString(), sender)) {
+        if (!plugin.getCommandsManager().hasPermission(AutorankPermission.RELOAD_AUTORANK, sender)) {
             return true;
         }
 
@@ -46,8 +46,8 @@ public class ReloadCommand extends AutorankCommand {
     }
 
     @Override
-    public String getPermission() {
-        return AutorankPermission.RELOAD_AUTORANK.getPermissionString();
+    public AutorankPermission getPermission() {
+        return AutorankPermission.RELOAD_AUTORANK;
     }
 
     @Override

--- a/src/me/armar/plugins/autorank/commands/RemoveCommand.java
+++ b/src/me/armar/plugins/autorank/commands/RemoveCommand.java
@@ -27,7 +27,7 @@ public class RemoveCommand extends AutorankCommand {
     @Override
     public boolean onCommand(final CommandSender sender, final Command cmd, final String label, final String[] args) {
 
-        if (!plugin.getCommandsManager().hasPermission(AutorankPermission.REMOVE_LOCAL_TIME.getPermissionString(), sender)) {
+        if (!plugin.getCommandsManager().hasPermission(AutorankPermission.REMOVE_LOCAL_TIME, sender)) {
             return true;
         }
 
@@ -89,8 +89,8 @@ public class RemoveCommand extends AutorankCommand {
     }
 
     @Override
-    public String getPermission() {
-        return AutorankPermission.REMOVE_LOCAL_TIME.getPermissionString();
+    public AutorankPermission getPermission() {
+        return AutorankPermission.REMOVE_LOCAL_TIME;
     }
 
     @Override

--- a/src/me/armar/plugins/autorank/commands/ResetCommand.java
+++ b/src/me/armar/plugins/autorank/commands/ResetCommand.java
@@ -25,7 +25,7 @@ public class ResetCommand extends AutorankCommand {
     @Override
     public boolean onCommand(final CommandSender sender, final Command cmd, final String label, final String[] args) {
 
-        if (!plugin.getCommandsManager().hasPermission(AutorankPermission.RESET_DATA.getPermissionString(), sender)) {
+        if (!plugin.getCommandsManager().hasPermission(AutorankPermission.RESET_DATA, sender)) {
             return true;
         }
 
@@ -69,8 +69,8 @@ public class ResetCommand extends AutorankCommand {
     }
 
     @Override
-    public String getPermission() {
-        return AutorankPermission.RESET_DATA.getPermissionString();
+    public AutorankPermission getPermission() {
+        return AutorankPermission.RESET_DATA;
     }
 
     @Override

--- a/src/me/armar/plugins/autorank/commands/SetCommand.java
+++ b/src/me/armar/plugins/autorank/commands/SetCommand.java
@@ -39,7 +39,7 @@ public class SetCommand extends AutorankCommand {
 
         if (value >= 0) {
 
-            if (!plugin.getCommandsManager().hasPermission(AutorankPermission.SET_LOCAL_TIME.getPermissionString(), sender)) {
+            if (!plugin.getCommandsManager().hasPermission(AutorankPermission.SET_LOCAL_TIME, sender)) {
                 return true;
             }
 
@@ -70,8 +70,8 @@ public class SetCommand extends AutorankCommand {
     }
 
     @Override
-    public String getPermission() {
-        return AutorankPermission.SET_LOCAL_TIME.getPermissionString();
+    public AutorankPermission getPermission() {
+        return AutorankPermission.SET_LOCAL_TIME;
     }
 
     @Override

--- a/src/me/armar/plugins/autorank/commands/SyncCommand.java
+++ b/src/me/armar/plugins/autorank/commands/SyncCommand.java
@@ -27,7 +27,7 @@ public class SyncCommand extends AutorankCommand {
     @Override
     public boolean onCommand(final CommandSender sender, final Command cmd, final String label, final String[] args) {
 
-        if (!plugin.getCommandsManager().hasPermission(AutorankPermission.SYNC_MYSQL_TABLE.getPermissionString(), sender))
+        if (!plugin.getCommandsManager().hasPermission(AutorankPermission.SYNC_MYSQL_TABLE, sender))
             return true;
 
         if (args.length > 1 && args[1].equalsIgnoreCase("stats")) {
@@ -98,8 +98,8 @@ public class SyncCommand extends AutorankCommand {
     }
 
     @Override
-    public String getPermission() {
-        return AutorankPermission.SYNC_MYSQL_TABLE.getPermissionString();
+    public AutorankPermission getPermission() {
+        return AutorankPermission.SYNC_MYSQL_TABLE;
     }
 
     @Override

--- a/src/me/armar/plugins/autorank/commands/SyncStatsCommand.java
+++ b/src/me/armar/plugins/autorank/commands/SyncStatsCommand.java
@@ -28,7 +28,7 @@ public class SyncStatsCommand extends AutorankCommand {
     @Override
     public boolean onCommand(final CommandSender sender, final Command cmd, final String label, final String[] args) {
 
-        if (!plugin.getCommandsManager().hasPermission(AutorankPermission.SYNC_STATS_DATA.getPermissionString(), sender))
+        if (!plugin.getCommandsManager().hasPermission(AutorankPermission.SYNC_STATS_DATA, sender))
             return true;
 
         if (!plugin.getHookedStatsPlugin().isEnabled()) {
@@ -72,8 +72,8 @@ public class SyncStatsCommand extends AutorankCommand {
     }
 
     @Override
-    public String getPermission() {
-        return AutorankPermission.SYNC_STATS_DATA.getPermissionString();
+    public AutorankPermission getPermission() {
+        return AutorankPermission.SYNC_STATS_DATA;
     }
 
     @Override

--- a/src/me/armar/plugins/autorank/commands/TimesCommand.java
+++ b/src/me/armar/plugins/autorank/commands/TimesCommand.java
@@ -38,14 +38,14 @@ public class TimesCommand extends AutorankCommand {
         // A player specified a target
         if (args.length > 1) {
 
-            if (!plugin.getCommandsManager().hasPermission(AutorankPermission.CHECK_TIME_PLAYED_OTHERS.getPermissionString(), sender)) {
+            if (!plugin.getCommandsManager().hasPermission(AutorankPermission.CHECK_TIME_PLAYED_OTHERS, sender)) {
                 return true;
             }
 
             targetName = args[1];
 
         } else if (sender instanceof Player) {
-            if (!plugin.getCommandsManager().hasPermission(AutorankPermission.CHECK_TIME_PLAYED_SELF.getPermissionString(), sender)) {
+            if (!plugin.getCommandsManager().hasPermission(AutorankPermission.CHECK_TIME_PLAYED_SELF, sender)) {
                 return true;
             }
 
@@ -92,8 +92,8 @@ public class TimesCommand extends AutorankCommand {
     }
 
     @Override
-    public String getPermission() {
-        return AutorankPermission.CHECK_TIME_PLAYED_SELF.getPermissionString();
+    public AutorankPermission getPermission() {
+        return AutorankPermission.CHECK_TIME_PLAYED_SELF;
     }
 
     @Override

--- a/src/me/armar/plugins/autorank/commands/TrackCommand.java
+++ b/src/me/armar/plugins/autorank/commands/TrackCommand.java
@@ -46,7 +46,7 @@ public class TrackCommand extends AutorankCommand {
          * ); return true; }
          */
 
-        if (!plugin.getCommandsManager().hasPermission(AutorankPermission.TRACK_REQUIREMENT.getPermissionString(), sender))
+        if (!plugin.getCommandsManager().hasPermission(AutorankPermission.TRACK_REQUIREMENT, sender))
             return true;
 
         final Player player = (Player) sender;
@@ -119,8 +119,8 @@ public class TrackCommand extends AutorankCommand {
     }
 
     @Override
-    public String getPermission() {
-        return AutorankPermission.TRACK_REQUIREMENT.getPermissionString();
+    public AutorankPermission getPermission() {
+        return AutorankPermission.TRACK_REQUIREMENT;
     }
 
     @Override

--- a/src/me/armar/plugins/autorank/commands/ViewCommand.java
+++ b/src/me/armar/plugins/autorank/commands/ViewCommand.java
@@ -34,7 +34,7 @@ public class ViewCommand extends AutorankCommand {
     public boolean onCommand(final CommandSender sender, final Command cmd, final String label, final String[] args) {
 
         // This command will give a preview of a certain path of ranking.
-        if (!plugin.getCommandsManager().hasPermission(AutorankPermission.VIEW_PATH.getPermissionString(), sender)) {
+        if (!plugin.getCommandsManager().hasPermission(AutorankPermission.VIEW_PATH, sender)) {
             return true;
         }
 
@@ -236,8 +236,8 @@ public class ViewCommand extends AutorankCommand {
     }
 
     @Override
-    public String getPermission() {
-        return AutorankPermission.VIEW_PATH.getPermissionString();
+    public AutorankPermission getPermission() {
+        return AutorankPermission.VIEW_PATH;
     }
 
     @Override

--- a/src/me/armar/plugins/autorank/commands/manager/AutorankCommand.java
+++ b/src/me/armar/plugins/autorank/commands/manager/AutorankCommand.java
@@ -2,6 +2,7 @@ package me.armar.plugins.autorank.commands.manager;
 
 import java.util.List;
 
+import me.armar.plugins.autorank.permissions.AutorankPermission;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabExecutor;
@@ -25,7 +26,7 @@ public abstract class AutorankCommand implements TabExecutor {
      * necessarily fits the command. Sometimes, multiple permissions are needed
      * to check if a player has access to this command.
      */
-    public abstract String getPermission();
+    public abstract AutorankPermission getPermission();
 
     /**
      * Get the way this command is supposed to be used. For example, /ar times

--- a/src/me/armar/plugins/autorank/commands/manager/CommandsManager.java
+++ b/src/me/armar/plugins/autorank/commands/manager/CommandsManager.java
@@ -40,6 +40,7 @@ import me.armar.plugins.autorank.commands.TimesCommand;
 import me.armar.plugins.autorank.commands.TrackCommand;
 import me.armar.plugins.autorank.commands.ViewCommand;
 import me.armar.plugins.autorank.language.Lang;
+import me.armar.plugins.autorank.permissions.AutorankPermission;
 import me.armar.plugins.autorank.util.AutorankTools;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.BaseComponent;
@@ -122,9 +123,9 @@ public class CommandsManager implements TabExecutor {
      *            Sender to check
      * @return true if this sender has the given permission, false otherwise.
      */
-    public boolean hasPermission(final String permission, final CommandSender sender) {
-        if (!sender.hasPermission(permission)) {
-            sender.sendMessage(ChatColor.RED + Lang.NO_PERMISSION.getConfigValue(permission));
+    public boolean hasPermission(final AutorankPermission permission, final CommandSender sender) {
+        if (!permission.allows(sender)) {
+            sender.sendMessage(ChatColor.RED + Lang.NO_PERMISSION.getConfigValue(permission.getPermissionString()));
             return false;
         }
         return true;

--- a/src/me/armar/plugins/autorank/data/flatfile/UpdatePlaytime.java
+++ b/src/me/armar/plugins/autorank/data/flatfile/UpdatePlaytime.java
@@ -72,7 +72,7 @@ public class UpdatePlaytime implements Runnable {
         plugin.getPlayerChecker().doLeaderboardExemptCheck(player);
 
         if (AutorankTools.isExcludedFromRanking(player)
-                || player.hasPermission(AutorankPermission.EXCLUDE_FROM_TIME_UPDATES.getPermissionString())) {
+                || AutorankPermission.EXCLUDE_FROM_TIME_UPDATES.allows(player)) {
             return;
         }
 

--- a/src/me/armar/plugins/autorank/listeners/PlayerJoinListener.java
+++ b/src/me/armar/plugins/autorank/listeners/PlayerJoinListener.java
@@ -58,7 +58,7 @@ public class PlayerJoinListener implements Listener {
         });
 
         // Player isn't allowed to see messages.
-        if (player.hasPermission(AutorankPermission.NOTICE_ON_UPDATE_AVAILABLE.getPermissionString())) {
+        if (AutorankPermission.NOTICE_ON_UPDATE_AVAILABLE.allows(player)) {
 
             // Run check async so server doesn't lag.
             plugin.getServer().getScheduler().runTaskAsynchronously(plugin, new Runnable() {
@@ -87,7 +87,7 @@ public class PlayerJoinListener implements Listener {
         }
 
         // If player has notice on warning permission
-        if (player.hasPermission(AutorankPermission.NOTICE_ON_WARNINGS.getPermissionString())) {
+        if (AutorankPermission.NOTICE_ON_WARNINGS.allows(player)) {
 
             if (plugin.getWarningManager().getHighestWarning() != null) {
 

--- a/src/me/armar/plugins/autorank/permissions/AutorankPermission.java
+++ b/src/me/armar/plugins/autorank/permissions/AutorankPermission.java
@@ -1,5 +1,7 @@
 package me.armar.plugins.autorank.permissions;
 
+import org.bukkit.command.CommandSender;
+
 /**
  * This class represents a permission node that is used by Autorank to check whether a player is able to perform an action.
  * @author Staartvin
@@ -56,6 +58,15 @@ public enum AutorankPermission {
      */
     public String getPermissionString() {
         return this.permissionString;
+    }
+
+    /**
+     * Check whether the given command sender has this permission.
+     * @param sender the command sender to check
+     * @return true if has permission, false otherwise
+     */
+    public boolean allows(CommandSender sender) {
+        return sender.hasPermission(permissionString);
     }
     
     @Override

--- a/src/me/armar/plugins/autorank/playerchecker/PlayerChecker.java
+++ b/src/me/armar/plugins/autorank/playerchecker/PlayerChecker.java
@@ -50,7 +50,7 @@ public class PlayerChecker {
 
     public void doLeaderboardExemptCheck(final Player player) {
         plugin.getPlayerDataConfig().hasLeaderboardExemption(player.getUniqueId(),
-                player.hasPermission(AutorankPermission.EXCLUDE_FROM_LEADERBOARD.getPermissionString()));
+                AutorankPermission.EXCLUDE_FROM_LEADERBOARD.allows(player));
     }
 
     public List<String> formatRequirementsToList(final List<RequirementsHolder> holders,

--- a/src/me/armar/plugins/autorank/util/AutorankTools.java
+++ b/src/me/armar/plugins/autorank/util/AutorankTools.java
@@ -432,7 +432,7 @@ public class AutorankTools {
             return true;
         }
 
-        if (player.hasPermission(AutorankPermission.EXCLUDE_FROM_PATHING.getPermissionString())) {
+        if (AutorankPermission.EXCLUDE_FROM_PATHING.allows(player)) {
             return true;
         }
 

--- a/src/me/armar/plugins/autorank/warningmanager/WarningNoticeTask.java
+++ b/src/me/armar/plugins/autorank/warningmanager/WarningNoticeTask.java
@@ -26,7 +26,7 @@ public class WarningNoticeTask implements Runnable {
         for (final Player p : plugin.getServer().getOnlinePlayers()) {
 
             // If player has notice on warning permission
-            if (p.hasPermission(AutorankPermission.NOTICE_ON_WARNINGS.getPermissionString()) || p.isOp()) {
+            if (AutorankPermission.NOTICE_ON_WARNINGS.allows(p) || p.isOp()) {
 
                plugin.getWarningManager().sendWarnings(p);
             }


### PR DESCRIPTION
Changes methods to use the `AutorankPermission` enum directly instead of casting to a String across the codebase. Introduces an `AutorankPermission#allows` method for checking if a command sender has the given permission.