### PR TITLE
Track leaderboard update times separately

### DIFF
--- a/src/me/armar/plugins/autorank/config/InternalPropertiesConfig.java
+++ b/src/me/armar/plugins/autorank/config/InternalPropertiesConfig.java
@@ -44,8 +44,8 @@ public class InternalPropertiesConfig {
      * 
      * @return a UNIX timestamp or 0 if never updated before.
      */
-    public long getLeaderboardLastUpdateTime() {
-        return config.getLong("leaderboard last updated", 0);
+    public long getLeaderboardLastUpdateTime(final TimeType type) {
+        return config.getLong("leaderboards." + type.toString().toLowerCase() + ".last updated", 0);
     }
 
     /**
@@ -162,8 +162,8 @@ public class InternalPropertiesConfig {
      * @param time
      *            Last update time (UNIX timestamp)
      */
-    public void setLeaderboardLastUpdateTime(final long time) {
-        config.set("leaderboard last updated", time);
+    public void setLeaderboardLastUpdateTime(final TimeType type, final long time) {
+        config.set("leaderboards." + type.toString().toLowerCase() + ".last updated", time);
 
         config.saveFile();
     }

--- a/src/me/armar/plugins/autorank/data/flatfile/FlatFileManager.java
+++ b/src/me/armar/plugins/autorank/data/flatfile/FlatFileManager.java
@@ -142,7 +142,7 @@ public class FlatFileManager {
                 // Update tracked data type
                 plugin.getInternalPropertiesConfig().setTrackedTimeType(type, value);
                 // We reset leaderboard time so it refreshes again.
-                plugin.getInternalPropertiesConfig().setLeaderboardLastUpdateTime(0);
+                plugin.getInternalPropertiesConfig().setLeaderboardLastUpdateTime(type, 0);
 
                 // Update leaderboard of reset time
                 plugin.getServer().getScheduler().runTaskAsynchronously(plugin, new Runnable() {

--- a/src/me/armar/plugins/autorank/leaderboard/LeaderboardHandler.java
+++ b/src/me/armar/plugins/autorank/leaderboard/LeaderboardHandler.java
@@ -292,7 +292,7 @@ public class LeaderboardHandler {
      * @return true if we should update the leaderboard
      */
     private boolean shouldUpdateLeaderboard(TimeType type) {
-        if (System.currentTimeMillis() - plugin.getInternalPropertiesConfig().getLeaderboardLastUpdateTime() > (60000
+        if (System.currentTimeMillis() - plugin.getInternalPropertiesConfig().getLeaderboardLastUpdateTime(type) > (60000
                 * LEADERBOARD_TIME_VALID)) {
             return true;
         } else if (plugin.getInternalPropertiesConfig().getCachedLeaderboard(type).size() <= 2) {
@@ -402,7 +402,7 @@ public class LeaderboardHandler {
         plugin.getInternalPropertiesConfig().setCachedLeaderboard(type, stringList);
 
         // Update latest update-time
-        plugin.getInternalPropertiesConfig().setLeaderboardLastUpdateTime(System.currentTimeMillis());
+        plugin.getInternalPropertiesConfig().setLeaderboardLastUpdateTime(type, System.currentTimeMillis());
     }
 
     /**


### PR DESCRIPTION
This fixes an issue where lesser used leaderboards (such as weekly or monthly) get updated very rarely when players primarily check the default leaderboard. The last refresh would always be considered recent when in reality a leaderboard may not have been updated in a while. 