### PR TITLE
SQL Table Prefix and Hikari Settings

### DIFF
--- a/Settings.yml
+++ b/Settings.yml
@@ -40,6 +40,7 @@ sql:
     username: root
     password: ''
     database: minecraft
+    table prefix: ''
     server name: '%name%-default'
 # All these options are for configuring your MySQL database with Autorank.
 # Hostname has to include a port, but doesn't have to be port 3306.

--- a/src/me/armar/plugins/autorank/config/SettingsConfig.java
+++ b/src/me/armar/plugins/autorank/config/SettingsConfig.java
@@ -11,12 +11,12 @@ import me.armar.plugins.autorank.Autorank;
 public class SettingsConfig extends AbstractConfig {
 
     /**
-     * Get the value of a specific MySQL credential.
+     * Get the value of a specific MySQL setting.
      *
-     * @param option Type of credential
-     * @return the value for the given MySQL credential.
+     * @param option Type of setting
+     * @return the value for the given MySQL setting.
      */
-    public String getMySQLCredentials(final MySQLCredentials option) {
+    public String getMySQLSetting(final MySQLSettings option) {
         switch (option) {
             case HOSTNAME:
                 return this.getConfig().getString("sql.hostname");
@@ -26,13 +26,15 @@ public class SettingsConfig extends AbstractConfig {
                 return this.getConfig().getString("sql.password");
             case DATABASE:
                 return this.getConfig().getString("sql.database");
+            case TABLE_PREFIX:
+                return this.getConfig().getString("sql.table prefix");
             case SERVER_NAME:
                 return this.getConfig().getString("sql.server name", "")
                         .replace("%ip%", getPlugin().getServer().getIp())
                         .replace("%port%", getPlugin().getServer().getPort() + "")
                         .replace("%name%", getPlugin().getServer().getName());
             default:
-                throw new IllegalArgumentException(option + " is not a valid MySQL credential option");
+                throw new IllegalArgumentException(option + " is not a valid MySQL settings option");
         }
     }
 
@@ -137,11 +139,11 @@ public class SettingsConfig extends AbstractConfig {
     }
 
     /**
-     * The different type of credentials that is used to connect to a MySQL
+     * The different types of settings that are used to connect to a MySQL
      * database.
      */
-    public enum MySQLCredentials {
-        DATABASE, HOSTNAME, PASSWORD, SERVER_NAME, USERNAME
+    public enum MySQLSettings {
+        DATABASE, HOSTNAME, PASSWORD, SERVER_NAME, TABLE_PREFIX, USERNAME
     }
 
     /**

--- a/src/me/armar/plugins/autorank/storage/mysql/MySQLStorageProvider.java
+++ b/src/me/armar/plugins/autorank/storage/mysql/MySQLStorageProvider.java
@@ -28,8 +28,6 @@ public class MySQLStorageProvider extends PlayTimeStorageProvider {
     public static int CACHE_EXPIRY_TIME = 2;
     // Thread pool for saving and retrieving storage.
     private ExecutorService executor = Executors.newSingleThreadExecutor();
-    // Variables to connect to database.
-    private String hostname, username, password, database;
     // Store table names for different time types
     private Map<TimeType, String> tableNames = new HashMap<>();
     // Use library to handle connections to MySQL database.
@@ -351,10 +349,12 @@ public class MySQLStorageProvider extends PlayTimeStorageProvider {
     }
 
     private void loadTableNames() {
-        tableNames.put(TimeType.TOTAL_TIME, "totalTime");
-        tableNames.put(TimeType.DAILY_TIME, "dailyTime");
-        tableNames.put(TimeType.WEEKLY_TIME, "weeklyTime");
-        tableNames.put(TimeType.MONTHLY_TIME, "monthlyTime");
+        String prefix = plugin.getSettingsConfig().getMySQLSetting(SettingsConfig.MySQLSettings.TABLE_PREFIX);
+
+        tableNames.put(TimeType.TOTAL_TIME, prefix + "totalTime");
+        tableNames.put(TimeType.DAILY_TIME, prefix + "dailyTime");
+        tableNames.put(TimeType.WEEKLY_TIME, prefix + "weeklyTime");
+        tableNames.put(TimeType.MONTHLY_TIME, prefix + "monthlyTime");
     }
 
     /**
@@ -371,20 +371,15 @@ public class MySQLStorageProvider extends PlayTimeStorageProvider {
                 return false;
             }
 
-            hostname = configHandler.getMySQLCredentials(SettingsConfig.MySQLCredentials.HOSTNAME);
-            username = configHandler.getMySQLCredentials(SettingsConfig.MySQLCredentials.USERNAME);
-            password = configHandler.getMySQLCredentials(SettingsConfig.MySQLCredentials.PASSWORD);
-            database = configHandler.getMySQLCredentials(SettingsConfig.MySQLCredentials.DATABASE);
-
-            mysqlLibrary = new SQLConnection(hostname, username, password, database);
+            mysqlLibrary = SQLConnection.getInstance(configHandler);
 
             if (!mysqlLibrary.connect()) {
                 mysqlLibrary = null;
-                plugin.getLogger().severe("Could not connect to " + hostname);
-                plugin.debugMessage(ChatColor.RED + "Could not connect to MYSQL!");
+                plugin.getLogger().severe("Could not connect to MySQL!");
+                plugin.debugMessage(ChatColor.RED + "Could not connect to MySQL!");
                 return false;
             } else {
-                plugin.debugMessage(ChatColor.RED + "Successfully established connection to " + hostname);
+                plugin.debugMessage(ChatColor.RED + "Successfully established connection to MySQL");
                 return true;
             }
         });


### PR DESCRIPTION
- Added the 'table prefix' option to Settings.yml to prefix tables in the SQL database. 
- SQLConnection is now Singleton, previously two instances of the Hiraki pool were created which is a very expensive operation.
- The settings for the Hiraki pool are optimized such that they do not generate warning messages every 30 minutes. (failed to validate connection (No operations allowed after connection closed.))